### PR TITLE
🚀 Automate Release Tagging and GitHub Release Updates  

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,8 @@ jobs:
     - name: Generate release tag
       id: generate_tag
       run: |
-        RELEASE_TAG=v$(date +'%Y%m%d%H%M%S')
+        chmod +x bump-version.sh
+        RELEASE_TAG=$(./bump-version.sh)
         echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
 
     # Step 6: Create Git tag
@@ -76,6 +77,9 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
+        draft: false
+        make_latest: true
+        generate_release_notes: true
         tag_name: ${{ env.RELEASE_TAG }}
         files: dynamic-notification-system-${{ env.RELEASE_TAG }}.zip
       env:

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
+# latest_tag=$(git tag --sort=committerdate | grep -o 'v.*' | sort -r | head -1 2>/dev/null)
+
+if [[ -z "$latest_tag" ]]; then
+  echo "v0.1.0"
+  exit 0
+fi
+
+major=$(echo "$latest_tag" | cut -d'.' -f1 | sed 's/v//')
+minor=$(echo "$latest_tag" | cut -d'.' -f2)
+patch=$(echo "$latest_tag" | cut -d'.' -f3)
+
+if git log --oneline -1 | grep -q "BREAKING CHANGE"; then
+  major=$((major + 1))
+  minor=0
+  patch=0
+elif git log --oneline -1 | grep -q "feat"; then
+  minor=$((minor + 1))
+  patch=0
+elif git log --oneline -1 | grep -q "fix"; then
+  patch=$((patch + 1))
+fi
+
+echo "v${major}.${minor}.${patch}"


### PR DESCRIPTION
#### 🔄 Changes:
- **Generate Release Tag**:  
  Added a step to run `bump-version.sh` to dynamically generate a release tag and store it in `$GITHUB_ENV`.

- **GitHub Release Enhancements**:  
  Updated the GitHub Release step to:  
  - ✅ Use the dynamic tag `${{ env.RELEASE_TAG }}`.  
  - ✅ Enable `make_latest` and `generate_release_notes`.  
  - ✅ Attach the release artifact `dynamic-notification-system-${{ env.RELEASE_TAG }}.zip`.  

#### ✅ Tasks:
- [x] Automate version tagging with `bump-version.sh`.  
- [x] Improve release documentation with auto-generated notes.  
- [x] Upload versioned release artifacts.

#### ⚡ Benefits:
- 🔧 Fully automated versioning and tagging process.  
- 📄 Better documentation with auto-generated release notes.  
- 📦 Simplified artifact distribution.  

🎉 Ready for review!
